### PR TITLE
Edit case sensitivity for Reminder/FriendBookParser

### DIFF
--- a/src/main/java/seedu/friendbook/commons/core/Messages.java
+++ b/src/main/java/seedu/friendbook/commons/core/Messages.java
@@ -12,5 +12,7 @@ public class Messages {
     public static final String MESSAGE_CONTAINS_FIELD_IN_BRACKETS = "Unable to parse command as %s field contains"
             + " fields enclosed in square brackets, e.g [t/TAG]\n"
             + "Please remove all enclosing square brackets.";
+    public static final String MESSAGE_COMMAND_CONTAINS_UPPERCASE = "%s command contains UPPERCASE characters."
+            + " Please enter LOWERCASE characters only";
 
 }

--- a/src/main/java/seedu/friendbook/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/friendbook/logic/commands/FindTagCommand.java
@@ -12,7 +12,7 @@ import seedu.friendbook.model.person.TagContainsKeywordsPredicate;
  */
 public class FindTagCommand extends Command {
 
-    public static final String COMMAND_WORD = "findTag";
+    public static final String COMMAND_WORD = "findtag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all friends whose tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/friendbook/logic/parser/FriendBookParser.java
+++ b/src/main/java/seedu/friendbook/logic/parser/FriendBookParser.java
@@ -1,5 +1,6 @@
 package seedu.friendbook.logic.parser;
 
+import static seedu.friendbook.commons.core.Messages.MESSAGE_COMMAND_CONTAINS_UPPERCASE;
 import static seedu.friendbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.friendbook.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -32,11 +33,16 @@ public class FriendBookParser {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     /**
-     * Parses user input into command for execution.
+     * Used to check if command contains any upper case characters
+     */
+    private static final String UPPER_CASE_REGEX = ".*[A-Z].*";
+
+    /**
+     * Parses user input(case-sensitive) into command for execution.
      *
      * @param userInput full user input string
      * @return the command based on the user input
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format, or contains uppercase
      */
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
@@ -46,6 +52,7 @@ public class FriendBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
@@ -79,9 +86,40 @@ public class FriendBookParser {
             return new ViewCommandParser().parse(arguments);
         case ProfileCommand.COMMAND_WORD:
             return new ProfileCommandParser().parse(arguments);
+
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            if (hasUpperCase(commandWord)) {
+                throw new ParseException(String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, commandWord.toLowerCase()));
+            } else {
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            }
         }
     }
 
+    /**
+     * Checks if the given command message contains uppercase characters.
+     * @return true if it is a valid command and contains uppercase characters.
+     */
+    public static boolean hasUpperCase(String message) {
+        return isAValidCommand(message) && message.matches(UPPER_CASE_REGEX);
+    }
+
+    /**
+     * Helper method to check if the command is valid.
+     * A command is valid if it is a case-insensitive version of the actual command word.
+     */
+    public static boolean isAValidCommand(String message) {
+        String lowerCaseCommand = message.toLowerCase();
+        return lowerCaseCommand.equals(AddCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(EditCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(DeleteCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(ClearCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(FindCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(FindTagCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(ListCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(ExitCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(HelpCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(ViewCommand.COMMAND_WORD)
+                || lowerCaseCommand.equals(ProfileCommand.COMMAND_WORD);
+    }
 }

--- a/src/main/java/seedu/friendbook/model/person/Avatar.java
+++ b/src/main/java/seedu/friendbook/model/person/Avatar.java
@@ -46,7 +46,7 @@ public class Avatar {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidAvatar(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) || test.trim().equals("");
     }
 
     @Override

--- a/src/main/java/seedu/friendbook/model/person/Birthday.java
+++ b/src/main/java/seedu/friendbook/model/person/Birthday.java
@@ -89,19 +89,32 @@ public class Birthday {
 
     /**
      * Calculates the remaining days until specified birthday
-     * If birthday falls on today's date, it considers the remaining days til next year's
      */
     public long calculateRemainingDaysToBirthday() {
+        if (isTodayBirthday()) {
+            return 0;
+        } else {
+            LocalDate today = LocalDate.now();
+            LocalDate birthday = LocalDate.parse(value);
+            LocalDate nextBday = birthday.withYear(today.getYear());
+
+            //If your birthday has occurred this year already, add 1 to the year.
+            if (nextBday.isBefore(today)) {
+                nextBday = nextBday.plusYears(1);
+            }
+
+            return ChronoUnit.DAYS.between(today, nextBday);
+        }
+    }
+
+    /**
+     * Helper method to check if specified birthday is today
+     */
+    public boolean isTodayBirthday() {
         LocalDate today = LocalDate.now();
         LocalDate birthday = LocalDate.parse(value);
-        LocalDate nextBday = birthday.withYear(today.getYear());
-
-        //If your birthday has occurred this year already, add 1 to the year.
-        if (nextBday.isBefore(today) || nextBday.equals(today)) {
-            nextBday = nextBday.plusYears(1);
-        }
-
-        return ChronoUnit.DAYS.between(today, nextBday);
+        return birthday.getMonth().equals(today.getMonth())
+                && birthday.getDayOfMonth() == today.getDayOfMonth();
     }
 
     /**

--- a/src/main/java/seedu/friendbook/model/reminder/Reminder.java
+++ b/src/main/java/seedu/friendbook/model/reminder/Reminder.java
@@ -16,7 +16,7 @@ public class Reminder {
      */
     public Reminder(String stringValue) {
         requireNonNull(stringValue);
-        this.stringValue = stringValue;
+        this.stringValue = stringValue.toLowerCase();
     }
 
     public String getStringValue() {
@@ -32,10 +32,10 @@ public class Reminder {
     }
 
     /**
-     * Returns true if a given reminder is valid.
+     * Returns true if a given reminder is valid. Values are case-insensitive
      */
     public static boolean isValidReminder(String test) {
-        return test.equals("on") || test.equals("off");
+        return test.equalsIgnoreCase("on") || test.equalsIgnoreCase("off") || test.trim().equals("");
     }
 
     @Override

--- a/src/test/java/seedu/friendbook/logic/parser/FriendBookParserTest.java
+++ b/src/test/java/seedu/friendbook/logic/parser/FriendBookParserTest.java
@@ -234,5 +234,7 @@ public class FriendBookParserTest {
         assertFalse(FriendBookParser.hasUpperCase(INVALID_ADD_COMMAND_WITH_UPPERCASE));
         assertFalse(FriendBookParser.hasUpperCase(INVALID_EDIT_COMMAND_WITH_UPPERCASE));
         assertFalse(FriendBookParser.hasUpperCase(INVALID_UNKNOWN_COMMAND_WITH_UPPERCASE));
+
+        assertFalse(FriendBookParser.hasUpperCase("add"));
     }
 }

--- a/src/test/java/seedu/friendbook/logic/parser/FriendBookParserTest.java
+++ b/src/test/java/seedu/friendbook/logic/parser/FriendBookParserTest.java
@@ -1,7 +1,9 @@
 package seedu.friendbook.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.friendbook.commons.core.Messages.MESSAGE_COMMAND_CONTAINS_UPPERCASE;
 import static seedu.friendbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.friendbook.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.friendbook.testutil.Assert.assertThrows;
@@ -32,6 +34,23 @@ import seedu.friendbook.testutil.PersonBuilder;
 import seedu.friendbook.testutil.PersonUtil;
 
 public class FriendBookParserTest {
+
+    private static final String ADD_COMMAND_WITH_UPPERCASE = "Add";
+    private static final String EDIT_COMMAND_WITH_UPPERCASE = "eDit";
+    private static final String DELETE_COMMAND_WITH_UPPERCASE = "deLete";
+    private static final String CLEAR_COMMAND_WITH_UPPERCASE = "CLEAR";
+    private static final String FIND_COMMAND_WITH_UPPERCASE = "FiND";
+    private static final String FINDTAG_COMMAND_WITH_UPPERCASE = "findTag";
+    private static final String LIST_COMMAND_WITH_UPPERCASE = "List";
+    private static final String EXIT_COMMAND_WITH_UPPERCASE = "EXIT";
+    private static final String HELP_COMMAND_WITH_UPPERCASE = "HelP";
+    private static final String VIEW_COMMAND_WITH_UPPERCASE = "VIew";
+    private static final String PROFILE_COMMAND_WITH_UPPERCASE = "PROFILe";
+
+    private static final String INVALID_ADD_COMMAND_WITH_UPPERCASE = "Adding";
+    private static final String INVALID_EDIT_COMMAND_WITH_UPPERCASE = "Editing";
+    private static final String INVALID_UNKNOWN_COMMAND_WITH_UPPERCASE = "asxvFSD";
+
 
     private final FriendBookParser parser = new FriendBookParser();
 
@@ -111,5 +130,109 @@ public class FriendBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void parseCommand_addCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "add"), () ->
+                parser.parseCommand(ADD_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_editCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "edit"), () ->
+                parser.parseCommand(EDIT_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_deleteCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "delete"), () ->
+                parser.parseCommand(DELETE_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_clearCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "clear"), () ->
+                parser.parseCommand(CLEAR_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_findCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "find"), () ->
+                parser.parseCommand(FIND_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_findtagCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "findtag"), () ->
+                parser.parseCommand(FINDTAG_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_listCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "list"), () ->
+                parser.parseCommand(LIST_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_exitCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "exit"), () ->
+                parser.parseCommand(EXIT_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_helpCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "help"), () ->
+                parser.parseCommand(HELP_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_viewCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "view"), () ->
+                parser.parseCommand(VIEW_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_profileCommandHasUpperCase_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_COMMAND_CONTAINS_UPPERCASE, "profile"), () ->
+                parser.parseCommand(PROFILE_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_isAValidCommand() {
+        assertTrue(FriendBookParser.isAValidCommand(ADD_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(EDIT_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(DELETE_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(CLEAR_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(FIND_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(FINDTAG_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(LIST_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(EXIT_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(HELP_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(VIEW_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.isAValidCommand(PROFILE_COMMAND_WITH_UPPERCASE));
+
+        assertFalse(FriendBookParser.isAValidCommand(INVALID_ADD_COMMAND_WITH_UPPERCASE));
+        assertFalse(FriendBookParser.isAValidCommand(INVALID_EDIT_COMMAND_WITH_UPPERCASE));
+        assertFalse(FriendBookParser.isAValidCommand(INVALID_UNKNOWN_COMMAND_WITH_UPPERCASE));
+    }
+
+    @Test
+    public void parseCommand_hasUpperCase() {
+        assertTrue(FriendBookParser.hasUpperCase(ADD_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(EDIT_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(DELETE_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(CLEAR_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(FIND_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(FINDTAG_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(LIST_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(EXIT_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(HELP_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(VIEW_COMMAND_WITH_UPPERCASE));
+        assertTrue(FriendBookParser.hasUpperCase(PROFILE_COMMAND_WITH_UPPERCASE));
+
+        assertFalse(FriendBookParser.hasUpperCase(INVALID_ADD_COMMAND_WITH_UPPERCASE));
+        assertFalse(FriendBookParser.hasUpperCase(INVALID_EDIT_COMMAND_WITH_UPPERCASE));
+        assertFalse(FriendBookParser.hasUpperCase(INVALID_UNKNOWN_COMMAND_WITH_UPPERCASE));
     }
 }

--- a/src/test/java/seedu/friendbook/model/person/AvatarTest.java
+++ b/src/test/java/seedu/friendbook/model/person/AvatarTest.java
@@ -24,12 +24,13 @@ public class AvatarTest {
         assertThrows(NullPointerException.class, () -> Avatar.isValidAvatar(null));
 
         // invalid name
-        assertFalse(Avatar.isValidAvatar("01")); // empty string
-        assertFalse(Avatar.isValidAvatar("24")); // spaces only
-        assertFalse(Avatar.isValidAvatar("-1")); // only non-alphanumeric characters
-        assertFalse(Avatar.isValidAvatar("00")); // contains non-alphanumeric characters
+        assertFalse(Avatar.isValidAvatar("01"));
+        assertFalse(Avatar.isValidAvatar("24"));
+        assertFalse(Avatar.isValidAvatar("-1"));
+        assertFalse(Avatar.isValidAvatar("00"));
 
         // valid name
+        assertTrue(Avatar.isValidAvatar(""));
         assertTrue(Avatar.isValidAvatar("1"));
         assertTrue(Avatar.isValidAvatar("12"));
         assertTrue(Avatar.isValidAvatar("20"));

--- a/src/test/java/seedu/friendbook/model/person/AvatarTest.java
+++ b/src/test/java/seedu/friendbook/model/person/AvatarTest.java
@@ -14,7 +14,7 @@ public class AvatarTest {
 
     @Test
     public void constructor_invalidName_throwsIllegalArgumentException() {
-        String invalidAvatar = "";
+        String invalidAvatar = "25";
         assertThrows(IllegalArgumentException.class, () -> new Avatar(invalidAvatar));
     }
 

--- a/src/test/java/seedu/friendbook/model/person/ReminderTest.java
+++ b/src/test/java/seedu/friendbook/model/person/ReminderTest.java
@@ -1,0 +1,38 @@
+package seedu.friendbook.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.friendbook.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.friendbook.model.reminder.Reminder;
+
+public class ReminderTest {
+
+    private static final String VALID_ON_REMINDER_LOWER_CASE = "on";
+    private static final String VALID_OFF_REMINDER_LOWER_CASE = "off";
+    private static final String VALID_ON_REMINDER_UPPER_CASE = "oN";
+    private static final String VALID_OFF_REMINDER_UPPER_CASE = "OFF";
+
+    private static final String INVALID_REMINDER_LOWER_CASE = "onoff";
+    private static final String INVALID_REMINDER_UPPER_CASE = "OnOff";
+
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Reminder(null));
+    }
+
+    @Test
+    public void isValidReminder() {
+        assertTrue(Reminder.isValidReminder(VALID_ON_REMINDER_LOWER_CASE));
+        assertTrue(Reminder.isValidReminder(VALID_OFF_REMINDER_LOWER_CASE));
+        assertTrue(Reminder.isValidReminder(VALID_ON_REMINDER_UPPER_CASE));
+        assertTrue(Reminder.isValidReminder(VALID_OFF_REMINDER_UPPER_CASE));
+        assertTrue(Reminder.isValidReminder(""));
+
+        assertFalse(Reminder.isValidReminder(INVALID_REMINDER_LOWER_CASE));
+        assertFalse(Reminder.isValidReminder(INVALID_REMINDER_UPPER_CASE));
+    }
+}

--- a/src/test/java/seedu/friendbook/model/person/TeleHandleTest.java
+++ b/src/test/java/seedu/friendbook/model/person/TeleHandleTest.java
@@ -13,9 +13,9 @@ public class TeleHandleTest {
     }
 
     @Test
-    public void constructor_invalidBirthday_throwsIllegalArgumentException() {
-        String invalidBirthday = "1993/04/20";
-        assertThrows(IllegalArgumentException.class, () -> new Birthday(invalidBirthday));
+    public void constructor_invalidTelehandle_throwsIllegalArgumentException() {
+        String invalidTeleHandle = "xyz";
+        assertThrows(IllegalArgumentException.class, () -> new TeleHandle(invalidTeleHandle));
     }
 
     @Test


### PR DESCRIPTION
1. Allow Reminder to accept case-insensitive versions e.g On, oFF, ON, OFF, on, off
2. Enforce Commands to only be lower-case e.g add/edit/delete/findtag/list. Informs user of specific errors if command input contains uppercase